### PR TITLE
Add links to TAPscan v4 paper

### DIFF
--- a/README_DEVELOPERS.md
+++ b/README_DEVELOPERS.md
@@ -36,7 +36,7 @@ While it is possible to update the data in TAPscan via the admin interface, it i
 
 ## adding news
 
-Do this via the database seeder, `database/seeders/DatabaseSeeder.php`
+Do this in `resources/views/news/index.blade.php`
 
 ## adding new database tables
 

--- a/resources/views/about/index.blade.php
+++ b/resources/views/about/index.blade.php
@@ -58,7 +58,7 @@
               <b>TAPscan v4</b>
             </td>
             <td>
-              TAPscan v4 is the latest version and was published in 2024 (<a href="https://www.biorxiv.org/content/10.1101/2024.07.13.602682v1" target="_blank">Petroll et al., preprint</a>) and enables the detection of 138 TAP families.
+              TAPscan v4 is the latest version and was published in December 2024 (<a href="http://doi.org/10.1111/tpj.17184" target="_blank">Petroll et al., <i>The Plant Journal</i></a>) and enables the detection of 138 TAP families.
               In addition, an updated web interface is available, making through the incorporation of the Genomezoo database
               even more TAP data available for the community. TAPscan v4 has also been made available as a Galaxy tool as
               part of the European Galaxy server (<a target="_blank" href="https://usegalaxy.eu">usegalaxy.eu</a>).

--- a/resources/views/news/index.blade.php
+++ b/resources/views/news/index.blade.php
@@ -4,24 +4,75 @@
 
 @section('content')
 
+<br>
+<div class="card text-center">
+  <div class="card-header">
+    CURRENT NEWS
+  </div>
 
-  @foreach ($news as $new)
+  <div class="card-body">
+    <h5 class="card-title">TAPscan v4 paper published!</h5>
+    <p class="card-text">
+    The TAPscan v4 paper has now been published in <i>The Plant Journal</i>. Read all about our work in <a href="http://doi.org/10.1111/tpj.17184" target="_blank">10.1111/tpj.17184</a>
+    <br><br>
+    <b>or cite TAPscan v4:</b>
+    <br><br>
+    Petroll, R., Varshney, D., Hiltemann, S., Finke, H., Schreiber, M., de Vries, J. and Rensing, S.A. (2024), Enhanced sensitivity of TAPscan v4 enables comprehensive analysis of streptophyte transcription factor evolution. Plant J. <a href="http://doi.org/10.1111/tpj.17184" target="_blank">https://doi.org/10.1111/tpj.17184</a>
 
-    <div class="card text-center">
-        @if ($loop->first)
-          <div class="card-header">
-         CURRENT NEWS
-         </div>
-       @endif
-      <div class="card-body">
-        <h5 class="card-title">{{$new->name}}</h5>
-        <p class="card-text">{{ Illuminate\Mail\Markdown::parse($new->content)}}</p>
-      </div>
-      <div class="card-footer text-muted">
-        {{$new->updated_at}}
-      </div>
-    </div>
-    <br>
-  @endforeach
+    </p>
+  </div>
+  <div class="card-footer text-muted">
+    2024-12-13 10:15:00
+  </div>
+</div>
+<br>
+<div class="card text-center">
+  <div class="card-body">
+    <h5 class="card-title">TAPscan v4 is out!</h5>
+    <p class="card-text">
+    We are happy to announce the new version 4 of TAPscan. This comprehensive update includes the addition of 18 new (sub) families, allowing TAPscan v4 to detect 138 TAP families. This update also includes an updated web interface, which enables to interactively explore the TAP data. By incorporating the <a target="_blank" href="https://github.com/Rensing-Lab/Genome-Zoo"> Genome Zoo dataset</a>, in addition to TAP data of the Archaeplastida, now also data of selected fungi, mammals, SAR group species, bacteria and archaea is made available throughout the TAPscan web interface.
+    <br><br>
+    TAPscan v4 has also been made available as a Galaxy tool as part of the European Galaxy server (<a target="_blank" href="https://usegalaxy.eu">usegalaxy.eu</a>).
+    <br><br>
+    In addition, the TAP information derived from the recently published (updated) genomes of Takakia lepidozioides (Hu et al., 2023), Mesotaenium endlicherianum  (Dadras et al., 2023) and Zygnema circumcarinatum (Feng et al., 2023) is made available.
+    <br><br>
+    More information about the update is available in the <a href="https://www.biorxiv.org/content/10.1101/2024.07.13.602682v1" target="_blank">TAPscan v4 preprint</a>.
+
+    See the <a href="/about">About page</a> for more information including version history and source code and data availability.
+
+    </p>
+  </div>
+  <div class="card-footer text-muted">
+    2024-05-24 12:42:00
+  </div>
+</div>
+<br>
+<div class="card text-center">
+  <div class="card-body">
+    <h5 class="card-title">Imported TAPscan v3 news"</h5>
+    <p class="card-text">
+      <b>30.07.2021</b> <br>
+      TAPscan V3 is out! Data of 10 red algae were added. The [publication in Genes](https://www.mdpi.com/2073-4425/12/7/1055) also describes the refinement of several TAP families in terms of enhanced sensitivity for algae. In addition, data derived from genomes meanwhile published have been released.
+      <br><br>
+      <b>13.07.2018</b><br>
+      The data derived from the genome of Chara braunii are released after [publication in Cell](https://authors.elsevier.com/a/1XNJfL7PXUhso).
+      <br><br>
+      <b>06.07.2018</b><br>
+      The data derived from the genomes of Azolla filiculoides and Salvinia cucullata are released after [publication in Nature Plants](https://www.nature.com/articles/s41477-018-0188-8).
+      <br><br>
+      <b>08.01.2018</b><br>
+      TAPscan and [PLAZA](https://bioinformatics.psb.ugent.be/plaza/) now cross link to each other on the level of individual proteins. When looking at a TAPscan protein sequence, please follow the 'Search for the protein on PLAZA' link to access the protein in PLAZA.
+      <br><br>
+      <b>08.12.2017</b><br>
+      TAPscan was published December 2017, please cite: <br>
+      <b>TAPscan - Comprehensive genome-wide classification reveals that many plant-specific transcription factors evolved in streptophyte algae. Wilhelmsson P.K., Mühlich C., Ullrich K.K., Rensing S.A. (2017) <a href="https://academic.oup.com/gbe/advance-article/doi/10.1093/gbe/evx258/4693820?guestAccessKey=fc717224-f2bb-452b-91a2-982f5fbd7489" target="_blank">Genome Biology and Evolution, evx258</a></b>
+    </p>
+  </div>
+  <div class="card-footer text-muted">
+    2024-05-24 12:42:00
+  </div>
+</div>
+
+<br>
 
 @endsection


### PR DESCRIPTION
- Add a news item about the publication of the paper.
- Replace the link to the preprint with the link to the published paper in the about page

Also I have simplified how the news page works, this doesn't need to be stored in the database, made it a simple static page now.